### PR TITLE
Makes Travis build our own

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
+
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"
+
 before_script:
   - npm install -g gulp
   - npm install -g mocha
+  - npm install
+
+script:
+  - gulp
+
 sudo: false


### PR DESCRIPTION
## Makes Travis build our own

This commit creates our own Travis build for our fork rather than relying on `qiao/PathFinding.js`'s build. 
